### PR TITLE
Update Definitions in Delete to fix removal of second to last element…

### DIFF
--- a/packages/core/src/elements/fieldsets/aujsf-array.ts
+++ b/packages/core/src/elements/fieldsets/aujsf-array.ts
@@ -36,6 +36,7 @@ export class AujsfArray extends AujsfBase<JsonSchemaArray, any[]> {
   public delete(index: number): void {
     if (index in this.value) {
       this.value.splice(index, 1);
+      this.definitions.splice(index, 1);
       this.updateDefinitions();
     }
   }


### PR DESCRIPTION
Update definitions during delete to avoid bug in updateDefinitions that deletes second to last element in array.